### PR TITLE
Fix ping icon not working with color codes

### DIFF
--- a/src/main/java/com/github/lunatrius/ingameinfo/tag/TagMisc.java
+++ b/src/main/java/com/github/lunatrius/ingameinfo/tag/TagMisc.java
@@ -4,6 +4,7 @@ import com.github.lunatrius.ingameinfo.client.gui.InfoIcon;
 import com.github.lunatrius.ingameinfo.tag.registry.TagRegistry;
 import net.minecraft.client.gui.GuiPlayerInfo;
 import net.minecraft.client.resources.ResourcePackRepository;
+import net.minecraft.util.EnumChatFormatting;
 
 import java.util.List;
 
@@ -156,7 +157,7 @@ public abstract class TagMisc extends Tag {
         public String getValue() {
             List<GuiPlayerInfo> list = player.sendQueue.playerInfoList;
             for (GuiPlayerInfo playerInfo : list) {
-                if (player.getGameProfile().getName().equals(playerInfo.name)) {
+                if (player.getGameProfile().getName().equals(EnumChatFormatting.getTextWithoutFormattingCodes(playerInfo.name))) {
                     int pingIndex = 4;
                     if (playerInfo.responseTime < 0) {
                         pingIndex = 5;


### PR DESCRIPTION
Names containing color codes on servers will cause ping icon to stop working, so it is -1 for everyone on official servers.
![image](https://user-images.githubusercontent.com/87545780/180618637-0bebc298-3c19-4629-ab72-8625179376ad.png)
