### PR TITLE
Change event subsciption for rendering

### DIFF
--- a/src/main/java/com/github/lunatrius/ingameinfo/InGameInfoCore.java
+++ b/src/main/java/com/github/lunatrius/ingameinfo/InGameInfoCore.java
@@ -49,6 +49,8 @@ public class InGameInfoCore {
     private final Map<Alignment, List<List<Value>>> format = new HashMap<>();
     private final List<Info> info = new ArrayList<>();
     private final List<Info> infoItemQueue = new ArrayList<>();
+    private ScaledResolution scaledResolution =
+            new ScaledResolution(this.minecraft, this.minecraft.displayWidth, this.minecraft.displayHeight);
 
     private InGameInfoCore() {
         Tag.setInfo(this.infoItemQueue);
@@ -88,8 +90,6 @@ public class InGameInfoCore {
     }
 
     public void onTickClient() {
-        ScaledResolution scaledResolution =
-                new ScaledResolution(this.minecraft, this.minecraft.displayWidth, this.minecraft.displayHeight);
         float scale = ConfigurationHandler.Scale / 10;
         int scaledWidth = (int) (scaledResolution.getScaledWidth() / scale);
         int scaledHeight = (int) (scaledResolution.getScaledHeight() / scale);
@@ -171,22 +171,15 @@ public class InGameInfoCore {
         ValueComplex.ValueFile.tick();
     }
 
-    public void onTickRender() {
-        // disable blending and reset to default (just in case)
-        // fixes "washed-out" / bright text
+    public void onTickRender(ScaledResolution resolution) {
+        this.scaledResolution = resolution;
+        GL11.glPushMatrix();
         float scale = ConfigurationHandler.Scale / 10;
-        GL11.glDisable(GL11.GL_BLEND);
-        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-
-        GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
         GL11.glScalef(scale, scale, scale);
-
         for (Info info : this.info) {
             info.draw();
         }
-
-        GL11.glScalef(1.0f / scale, 1.0f / scale, 1.0f / scale);
-        GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
+        GL11.glPopMatrix();
     }
 
     public boolean loadConfig(String filename) {

--- a/src/main/java/com/github/lunatrius/ingameinfo/handler/Ticker.java
+++ b/src/main/java/com/github/lunatrius/ingameinfo/handler/Ticker.java
@@ -28,12 +28,28 @@ public class Ticker {
 
     @SubscribeEvent
     public void onClientTick(TickEvent.ClientTickEvent event) {
-        onTick(event);
+        if (event.side == Side.CLIENT && event.phase == TickEvent.Phase.END) {
+            this.client.mcProfiler.startSection("ingameinfo");
+            if (isRunning()) {
+                this.core.onTickClient();
+            }
+            if (!ConfigurationHandler.showHUD || this.client.gameSettings == null) {
+                Tag.setServer(null);
+                Tag.releaseResources();
+            }
+            this.client.mcProfiler.endSection();
+        }
     }
 
     @SubscribeEvent
-    public void onRenderTick(TickEvent.RenderTickEvent event) {
-        onTick(event);
+    public void onRenderGUI(RenderGameOverlayEvent.Post event) {
+        if (event.type == RenderGameOverlayEvent.ElementType.TEXT) {
+            this.client.mcProfiler.startSection("ingameinfo");
+            if (isRunning()) {
+                this.core.onTickRender(event.resolution);
+            }
+            this.client.mcProfiler.endSection();
+        }
     }
 
     private boolean isRunning() {
@@ -65,25 +81,5 @@ public class Ticker {
         }
 
         return false;
-    }
-
-    private void onTick(TickEvent event) {
-        if (event.side == Side.CLIENT && event.phase == TickEvent.Phase.END) {
-            this.client.mcProfiler.startSection("ingameinfo");
-            if (isRunning()) {
-                if (event.type == TickEvent.Type.CLIENT) {
-                    this.core.onTickClient();
-                } else if (event.type == TickEvent.Type.RENDER) {
-                    this.core.onTickRender();
-                }
-            }
-
-            if ((!ConfigurationHandler.showHUD || this.client.gameSettings == null)
-                    && event.type == TickEvent.Type.CLIENT) {
-                Tag.setServer(null);
-                Tag.releaseResources();
-            }
-            this.client.mcProfiler.endSection();
-        }
     }
 }


### PR DESCRIPTION
- Use the `RenderGameOverlayEvent.Post` instead of the `TickEvent.RenderTickEvent` event to render HUD elements

- Use the scaled resolution of the event instead of computing a new one

- Deleted hazardous GL11 calls