### PR TITLE
Fix server incompatibility, add messaging for rain variable

### DIFF
--- a/src/main/java/com/github/lunatrius/ingameinfo/InGameInfoCore.java
+++ b/src/main/java/com/github/lunatrius/ingameinfo/InGameInfoCore.java
@@ -27,7 +27,7 @@ import org.lwjgl.opengl.GL11;
 
 import com.github.lunatrius.ingameinfo.client.gui.Info;
 import com.github.lunatrius.ingameinfo.client.gui.InfoText;
-import com.github.lunatrius.ingameinfo.handler.ConfigurationHandler;
+import com.github.lunatrius.ingameinfo.handler.ClientConfigurationHandler;
 import com.github.lunatrius.ingameinfo.parser.IParser;
 import com.github.lunatrius.ingameinfo.parser.json.JsonParser;
 import com.github.lunatrius.ingameinfo.parser.text.TextParser;
@@ -130,7 +130,7 @@ public class InGameInfoCore {
     }
 
     public void onTickClient() {
-        float scale = ConfigurationHandler.Scale / 10;
+        float scale = ClientConfigurationHandler.Scale / 10;
         int scaledWidth = (int) (scaledResolution.getScaledWidth() / scale);
         int scaledHeight = (int) (scaledResolution.getScaledHeight() / scale);
 
@@ -214,7 +214,7 @@ public class InGameInfoCore {
     public void onTickRender(ScaledResolution resolution) {
         this.scaledResolution = resolution;
         GL11.glPushMatrix();
-        float scale = ConfigurationHandler.Scale / 10;
+        float scale = ClientConfigurationHandler.Scale / 10;
         GL11.glScalef(scale, scale, scale);
         for (Info info : this.info) {
             info.draw();

--- a/src/main/java/com/github/lunatrius/ingameinfo/handler/ClientConfigurationHandler.java
+++ b/src/main/java/com/github/lunatrius/ingameinfo/handler/ClientConfigurationHandler.java
@@ -1,0 +1,21 @@
+package com.github.lunatrius.ingameinfo.handler;
+
+import net.minecraft.client.resources.IResourceManager;
+import net.minecraft.client.resources.IResourceManagerReloadListener;
+
+import com.github.lunatrius.ingameinfo.InGameInfoCore;
+
+public class ClientConfigurationHandler extends ConfigurationHandler implements IResourceManagerReloadListener {
+
+    public static final ClientConfigurationHandler INSTANCE = new ClientConfigurationHandler();
+
+    private ClientConfigurationHandler() {
+        super();
+    }
+
+    @Override
+    public void onResourceManagerReload(IResourceManager p_110549_1_) {
+        InGameInfoCore.INSTANCE.setConfigFileWithLocale();
+        InGameInfoCore.INSTANCE.reloadConfig();
+    }
+}

--- a/src/main/java/com/github/lunatrius/ingameinfo/handler/ConfigurationHandler.java
+++ b/src/main/java/com/github/lunatrius/ingameinfo/handler/ConfigurationHandler.java
@@ -5,20 +5,17 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import net.minecraft.client.resources.IResourceManager;
-import net.minecraft.client.resources.IResourceManagerReloadListener;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.common.config.Property;
 
 import com.github.lunatrius.ingameinfo.Alignment;
-import com.github.lunatrius.ingameinfo.InGameInfoCore;
 import com.github.lunatrius.ingameinfo.reference.Names;
 import com.github.lunatrius.ingameinfo.reference.Reference;
 
 import cpw.mods.fml.client.event.ConfigChangedEvent;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 
-public class ConfigurationHandler implements IResourceManagerReloadListener {
+public class ConfigurationHandler {
 
     public static final ConfigurationHandler INSTANCE = new ConfigurationHandler();
 
@@ -50,7 +47,7 @@ public class ConfigurationHandler implements IResourceManagerReloadListener {
     public static Property propFileInterval = null;
     public static final Map<Alignment, Property> propAlignments = new HashMap<>();
 
-    private ConfigurationHandler() {}
+    protected ConfigurationHandler() {}
 
     public static void init(File configFile) {
         if (configuration == null) {
@@ -59,7 +56,7 @@ public class ConfigurationHandler implements IResourceManagerReloadListener {
         }
     }
 
-    private static void loadConfiguration() {
+    protected static void loadConfiguration() {
 
         // spotless:off
 
@@ -129,12 +126,6 @@ public class ConfigurationHandler implements IResourceManagerReloadListener {
 
     public static void setConfigName(String name) {
         propConfigName.set(name);
-    }
-
-    @Override
-    public void onResourceManagerReload(IResourceManager p_110549_1_) {
-        InGameInfoCore.INSTANCE.setConfigFileWithLocale();
-        InGameInfoCore.INSTANCE.reloadConfig();
     }
 
     @SubscribeEvent

--- a/src/main/java/com/github/lunatrius/ingameinfo/handler/WorldHandler.java
+++ b/src/main/java/com/github/lunatrius/ingameinfo/handler/WorldHandler.java
@@ -1,0 +1,25 @@
+package com.github.lunatrius.ingameinfo.handler;
+
+import com.github.lunatrius.ingameinfo.network.PacketHandler;
+import com.github.lunatrius.ingameinfo.network.message.MessageNextRain;
+import com.github.lunatrius.ingameinfo.reference.Reference;
+
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.TickEvent;
+import cpw.mods.fml.relauncher.Side;
+
+public class WorldHandler {
+
+    @SubscribeEvent
+    public void onWorldTick(TickEvent.WorldTickEvent event) {
+        if (event.side == Side.SERVER && event.phase == TickEvent.Phase.END) {
+            try {
+                PacketHandler.INSTANCE.sendToDimension(
+                        new MessageNextRain(event.world.getWorldInfo().getRainTime()),
+                        event.world.provider.dimensionId);
+            } catch (Exception ex) {
+                Reference.logger.error("Failed to get rain!", ex);
+            }
+        }
+    }
+}

--- a/src/main/java/com/github/lunatrius/ingameinfo/network/PacketHandler.java
+++ b/src/main/java/com/github/lunatrius/ingameinfo/network/PacketHandler.java
@@ -1,5 +1,6 @@
 package com.github.lunatrius.ingameinfo.network;
 
+import com.github.lunatrius.ingameinfo.network.message.MessageNextRain;
 import com.github.lunatrius.ingameinfo.network.message.MessageSeed;
 import com.github.lunatrius.ingameinfo.reference.Reference;
 
@@ -14,5 +15,6 @@ public class PacketHandler {
 
     public static void init() {
         INSTANCE.registerMessage(MessageSeed.class, MessageSeed.class, 0, Side.CLIENT);
+        INSTANCE.registerMessage(MessageNextRain.class, MessageNextRain.class, 0, Side.CLIENT);
     }
 }

--- a/src/main/java/com/github/lunatrius/ingameinfo/network/message/MessageNextRain.java
+++ b/src/main/java/com/github/lunatrius/ingameinfo/network/message/MessageNextRain.java
@@ -1,0 +1,41 @@
+package com.github.lunatrius.ingameinfo.network.message;
+
+import com.github.lunatrius.ingameinfo.tag.Tag;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import cpw.mods.fml.relauncher.Side;
+import io.netty.buffer.ByteBuf;
+
+public class MessageNextRain implements IMessage, IMessageHandler<MessageNextRain, IMessage> {
+
+    public int rainTime;
+
+    public MessageNextRain() {
+        this.rainTime = 0;
+    }
+
+    public MessageNextRain(int rainTime) {
+        this.rainTime = rainTime;
+    }
+
+    @Override
+    public void fromBytes(ByteBuf buf) {
+        this.rainTime = buf.readInt();
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf) {
+        buf.writeInt(this.rainTime);
+    }
+
+    @Override
+    public IMessage onMessage(MessageNextRain message, MessageContext ctx) {
+        if (ctx.side == Side.CLIENT) {
+            Tag.setNextRain(message.rainTime);
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/github/lunatrius/ingameinfo/proxy/ClientProxy.java
+++ b/src/main/java/com/github/lunatrius/ingameinfo/proxy/ClientProxy.java
@@ -8,7 +8,7 @@ import net.minecraftforge.common.MinecraftForge;
 
 import com.github.lunatrius.ingameinfo.InGameInfoCore;
 import com.github.lunatrius.ingameinfo.command.InGameInfoCommand;
-import com.github.lunatrius.ingameinfo.handler.ConfigurationHandler;
+import com.github.lunatrius.ingameinfo.handler.ClientConfigurationHandler;
 import com.github.lunatrius.ingameinfo.handler.KeyInputHandler;
 import com.github.lunatrius.ingameinfo.handler.Ticker;
 import com.github.lunatrius.ingameinfo.integration.PluginLoader;
@@ -33,19 +33,20 @@ public class ClientProxy extends CommonProxy {
     @Override
     public void preInit(FMLPreInitializationEvent event) {
         super.preInit(event);
+        ClientConfigurationHandler.init(event.getSuggestedConfigurationFile());
 
         ValueRegistry.INSTANCE.init();
 
         PluginLoader.getInstance().preInit(event);
 
-        this.core.moveConfig(event.getModConfigurationDirectory(), ConfigurationHandler.configName);
+        this.core.moveConfig(event.getModConfigurationDirectory(), ClientConfigurationHandler.configName);
         this.core.setConfigDirectory(
                 event.getModConfigurationDirectory().toPath().resolve(Names.Files.SUBDIRECTORY).toFile());
-        this.core.setConfigFileWithLocale(ConfigurationHandler.configName);
+        this.core.setConfigFileWithLocale(ClientConfigurationHandler.configName);
         this.core.reloadConfig();
 
-        ConfigurationHandler.propFileInterval.setConfigEntryClass(GuiConfigEntries.NumberSliderEntry.class);
-        ConfigurationHandler.propscale.setConfigEntryClass(GuiConfigEntries.NumberSliderEntry.class);
+        ClientConfigurationHandler.propFileInterval.setConfigEntryClass(GuiConfigEntries.NumberSliderEntry.class);
+        ClientConfigurationHandler.propscale.setConfigEntryClass(GuiConfigEntries.NumberSliderEntry.class);
 
         for (KeyBinding keyBinding : KeyInputHandler.KEY_BINDINGS) {
             ClientRegistry.registerKeyBinding(keyBinding);
@@ -58,11 +59,11 @@ public class ClientProxy extends CommonProxy {
 
         MinecraftForge.EVENT_BUS.register(Ticker.INSTANCE);
         FMLCommonHandler.instance().bus().register(Ticker.INSTANCE);
-        FMLCommonHandler.instance().bus().register(ConfigurationHandler.INSTANCE);
+        FMLCommonHandler.instance().bus().register(ClientConfigurationHandler.INSTANCE);
         FMLCommonHandler.instance().bus().register(KeyInputHandler.INSTANCE);
         ClientCommandHandler.instance.registerCommand(InGameInfoCommand.INSTANCE);
         ((IReloadableResourceManager) Minecraft.getMinecraft().getResourceManager())
-                .registerReloadListener(ConfigurationHandler.INSTANCE);
+                .registerReloadListener(ClientConfigurationHandler.INSTANCE);
     }
 
     @Override

--- a/src/main/java/com/github/lunatrius/ingameinfo/proxy/CommonProxy.java
+++ b/src/main/java/com/github/lunatrius/ingameinfo/proxy/CommonProxy.java
@@ -1,6 +1,5 @@
 package com.github.lunatrius.ingameinfo.proxy;
 
-import com.github.lunatrius.ingameinfo.handler.ConfigurationHandler;
 import com.github.lunatrius.ingameinfo.network.PacketHandler;
 import com.github.lunatrius.ingameinfo.reference.Reference;
 
@@ -14,7 +13,6 @@ public class CommonProxy {
 
     public void preInit(FMLPreInitializationEvent event) {
         Reference.logger = event.getModLog();
-        ConfigurationHandler.init(event.getSuggestedConfigurationFile());
     }
 
     public void init(FMLInitializationEvent event) {

--- a/src/main/java/com/github/lunatrius/ingameinfo/proxy/ServerProxy.java
+++ b/src/main/java/com/github/lunatrius/ingameinfo/proxy/ServerProxy.java
@@ -1,14 +1,23 @@
 package com.github.lunatrius.ingameinfo.proxy;
 
+import com.github.lunatrius.ingameinfo.handler.ConfigurationHandler;
 import com.github.lunatrius.ingameinfo.handler.PlayerHandler;
+import com.github.lunatrius.ingameinfo.handler.WorldHandler;
 
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
+import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 
 public class ServerProxy extends CommonProxy {
+
+    public void preInit(FMLPreInitializationEvent event) {
+        super.preInit(event);
+        ConfigurationHandler.init(event.getSuggestedConfigurationFile());
+    }
 
     @Override
     public void init(FMLInitializationEvent event) {
         FMLCommonHandler.instance().bus().register(new PlayerHandler());
+        FMLCommonHandler.instance().bus().register(new WorldHandler());
     }
 }

--- a/src/main/java/com/github/lunatrius/ingameinfo/tag/Tag.java
+++ b/src/main/java/com/github/lunatrius/ingameinfo/tag/Tag.java
@@ -24,6 +24,8 @@ public abstract class Tag {
     protected static List<Info> info;
     protected static boolean hasSeed = false;
     protected static long seed = 0;
+    protected static boolean hasNextRainTime = false;
+    protected static int nextRainTime = 0;
 
     private String name = null;
     private String[] aliases = new String[0];
@@ -92,6 +94,16 @@ public abstract class Tag {
     public static void unsetSeed() {
         Tag.hasSeed = false;
         Tag.seed = 0;
+    }
+
+    public static void setNextRain(int rain) {
+        Tag.hasNextRainTime = true;
+        Tag.nextRainTime = rain;
+    }
+
+    public static void unsetNextRain() {
+        Tag.hasNextRainTime = false;
+        Tag.nextRainTime = 0;
     }
 
     public static void setWorld(World world) {

--- a/src/main/java/com/github/lunatrius/ingameinfo/tag/TagWorld.java
+++ b/src/main/java/com/github/lunatrius/ingameinfo/tag/TagWorld.java
@@ -170,11 +170,17 @@ public abstract class TagWorld extends Tag {
 
         @Override
         public String getValue() {
+            int seconds;
             if (server == null) {
-                return "?";
+                if (hasNextRainTime) {
+                    seconds = nextRainTime / 20;
+                } else {
+                    return "?";
+                }
+            } else {
+                seconds = server.worldServers[0].getWorldInfo().getRainTime() / 20;
             }
 
-            int seconds = server.worldServers[0].getWorldInfo().getRainTime() / 20;
             if (seconds < 60) {
                 return String.format(Locale.ENGLISH, "%ds", seconds);
             } else if (seconds < 3600) {


### PR DESCRIPTION
This should fix the IGI mod becoming client-side only as of v2.8.7, which caused the mod to crash if installed on a server, thus breaking any server provided information (which at the moment is only world seed and rain time, but others can be added if desired).

This is IMO a better fix for https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/16572, as such I would recommend removing the port checks in the XML config for local vs remote servers, and just keep the info in the XML the same between SP and MP servers with this fix.