### PR TITLE
Fix some icons not being found

### DIFF
--- a/src/main/java/com/github/lunatrius/ingameinfo/value/ValueComplex.java
+++ b/src/main/java/com/github/lunatrius/ingameinfo/value/ValueComplex.java
@@ -268,7 +268,7 @@ public abstract class ValueComplex extends Value {
                     return "";
                 }
 
-                if (size == 1 || size == 2) {
+                if ((size == 1 || size == 2) && !what.endsWith(".png")) {
                     int metadata = 0;
                     if (size == 2) {
                         metadata = getIntValue(1);
@@ -288,9 +288,7 @@ public abstract class ValueComplex extends Value {
 
                     InfoItem item = new InfoItem(itemStack);
                     item.setIdentifier(what);
-                    if (parent != null) {
-                        parent.attachValue(getName(), item);
-                    }
+                    parent.attachValue(getName(), item);
                     return Tag.getIconTag(item);
                 }
 
@@ -316,9 +314,7 @@ public abstract class ValueComplex extends Value {
                     icon.setTextureData(iconX, iconY, iconWidth, iconHeight, textureWidth, textureHeight);
                 }
 
-                if (parent != null) {
-                    parent.attachValue(getName(), icon);
-                }
+                parent.attachValue(getName(), icon);
                 return Tag.getIconTag(icon);
             } catch (Exception e) {
                 return "?";


### PR DESCRIPTION
Some icons were being incorrectly lumped in with item icons.

Both of these were lacking their icon previously but works as expected now.
![igi_icon](https://github.com/user-attachments/assets/2033570b-29e0-4e53-baba-48be000adae6)
![igi_icon2](https://github.com/user-attachments/assets/723ed937-f08c-4ac6-b61c-4fdeb842f1d2)
