### PR TITLE
fix WorldClient memory leak

### DIFF
--- a/src/main/java/com/github/lunatrius/ingameinfo/InGameInfoCore.java
+++ b/src/main/java/com/github/lunatrius/ingameinfo/InGameInfoCore.java
@@ -132,7 +132,6 @@ public class InGameInfoCore {
             }
         }
 
-        Tag.releaseResources();
         ValueComplex.ValueFile.tick();
     }
 

--- a/src/main/java/com/github/lunatrius/ingameinfo/command/InGameInfoCommand.java
+++ b/src/main/java/com/github/lunatrius/ingameinfo/command/InGameInfoCommand.java
@@ -18,11 +18,7 @@ import com.github.lunatrius.ingameinfo.reference.Names;
 
 public class InGameInfoCommand extends CommandBase {
 
-    public static final InGameInfoCommand INSTANCE = new InGameInfoCommand();
-
     private final InGameInfoCore core = InGameInfoCore.INSTANCE;
-
-    private InGameInfoCommand() {}
 
     @Override
     public String getCommandName() {

--- a/src/main/java/com/github/lunatrius/ingameinfo/handler/KeyInputHandler.java
+++ b/src/main/java/com/github/lunatrius/ingameinfo/handler/KeyInputHandler.java
@@ -1,17 +1,27 @@
 package com.github.lunatrius.ingameinfo.handler;
 
-import static com.github.lunatrius.ingameinfo.proxy.ClientProxy.KEY_BINDING_TOGGLE;
 import static cpw.mods.fml.common.gameevent.InputEvent.KeyInputEvent;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.settings.KeyBinding;
 
+import org.lwjgl.input.Keyboard;
+
+import com.github.lunatrius.ingameinfo.reference.Names;
+
+import cpw.mods.fml.client.registry.ClientRegistry;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 
 public class KeyInputHandler {
 
-    public static final KeyInputHandler INSTANCE = new KeyInputHandler();
+    private static final KeyBinding KEY_BINDING_TOGGLE = new KeyBinding(
+            Names.Keys.TOGGLE,
+            Keyboard.KEY_NONE,
+            Names.Keys.CATEGORY);
 
-    private KeyInputHandler() {}
+    public KeyInputHandler() {
+        ClientRegistry.registerKeyBinding(KEY_BINDING_TOGGLE);
+    }
 
     @SubscribeEvent
     public void onKeyInput(KeyInputEvent event) {

--- a/src/main/java/com/github/lunatrius/ingameinfo/handler/Ticker.java
+++ b/src/main/java/com/github/lunatrius/ingameinfo/handler/Ticker.java
@@ -11,7 +11,6 @@ import com.github.lunatrius.ingameinfo.tag.Tag;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.TickEvent;
-import cpw.mods.fml.relauncher.Side;
 
 public class Ticker {
 
@@ -28,13 +27,12 @@ public class Ticker {
 
     @SubscribeEvent
     public void onClientTick(TickEvent.ClientTickEvent event) {
-        if (event.side == Side.CLIENT && event.phase == TickEvent.Phase.END) {
+        if (event.phase == TickEvent.Phase.END) {
             this.client.mcProfiler.startSection("ingameinfo");
             if (isRunning()) {
                 this.core.onTickClient();
             }
-            if (!ConfigurationHandler.showHUD || this.client.gameSettings == null) {
-                Tag.setServer(null);
+            if (!ConfigurationHandler.showHUD) {
                 Tag.releaseResources();
             }
             this.client.mcProfiler.endSection();

--- a/src/main/java/com/github/lunatrius/ingameinfo/handler/Ticker.java
+++ b/src/main/java/com/github/lunatrius/ingameinfo/handler/Ticker.java
@@ -15,11 +15,8 @@ import cpw.mods.fml.relauncher.Side;
 
 public class Ticker {
 
-    public static final Ticker INSTANCE = new Ticker();
     private final Minecraft client = Minecraft.getMinecraft();
     private final InGameInfoCore core = InGameInfoCore.INSTANCE;
-
-    private Ticker() {}
 
     @SubscribeEvent
     public void onRenderGameOverlayEventPre(RenderGameOverlayEvent.Pre event) {

--- a/src/main/java/com/github/lunatrius/ingameinfo/handler/Ticker.java
+++ b/src/main/java/com/github/lunatrius/ingameinfo/handler/Ticker.java
@@ -32,9 +32,7 @@ public class Ticker {
             if (isRunning()) {
                 this.core.onTickClient();
             }
-            if (!ConfigurationHandler.showHUD) {
-                Tag.releaseResources();
-            }
+            Tag.releaseResources();
             this.client.mcProfiler.endSection();
         }
     }

--- a/src/main/java/com/github/lunatrius/ingameinfo/handler/TickerManager.java
+++ b/src/main/java/com/github/lunatrius/ingameinfo/handler/TickerManager.java
@@ -1,0 +1,35 @@
+package com.github.lunatrius.ingameinfo.handler;
+
+import net.minecraftforge.common.MinecraftForge;
+
+import com.github.lunatrius.ingameinfo.tag.Tag;
+
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.network.FMLNetworkEvent;
+
+public class TickerManager {
+
+    private Ticker ticker = null;
+
+    @SubscribeEvent
+    public void onClientConnect(FMLNetworkEvent.ClientConnectedToServerEvent event) {
+        if (this.ticker == null) {
+            this.ticker = new Ticker();
+            MinecraftForge.EVENT_BUS.register(this.ticker);
+            FMLCommonHandler.instance().bus().register(this.ticker);
+        }
+    }
+
+    @SubscribeEvent
+    public void onClientDisconnect(FMLNetworkEvent.ClientDisconnectionFromServerEvent event) {
+        if (this.ticker != null) {
+            MinecraftForge.EVENT_BUS.unregister(this.ticker);
+            FMLCommonHandler.instance().bus().unregister(this.ticker);
+            this.ticker = null;
+            Tag.releaseResources();
+            Tag.onClientDisconnect();
+        }
+    }
+
+}

--- a/src/main/java/com/github/lunatrius/ingameinfo/proxy/ClientProxy.java
+++ b/src/main/java/com/github/lunatrius/ingameinfo/proxy/ClientProxy.java
@@ -2,11 +2,8 @@ package com.github.lunatrius.ingameinfo.proxy;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.IReloadableResourceManager;
-import net.minecraft.client.settings.KeyBinding;
 import net.minecraftforge.client.ClientCommandHandler;
 import net.minecraftforge.common.MinecraftForge;
-
-import org.lwjgl.input.Keyboard;
 
 import com.github.lunatrius.ingameinfo.InGameInfoCore;
 import com.github.lunatrius.ingameinfo.command.InGameInfoCommand;
@@ -20,7 +17,6 @@ import com.github.lunatrius.ingameinfo.tag.registry.TagRegistry;
 import com.github.lunatrius.ingameinfo.value.registry.ValueRegistry;
 
 import cpw.mods.fml.client.config.GuiConfigEntries;
-import cpw.mods.fml.client.registry.ClientRegistry;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
@@ -29,11 +25,6 @@ import cpw.mods.fml.common.event.FMLServerStartingEvent;
 import cpw.mods.fml.common.event.FMLServerStoppingEvent;
 
 public class ClientProxy extends CommonProxy {
-
-    public static final KeyBinding KEY_BINDING_TOGGLE = new KeyBinding(
-            Names.Keys.TOGGLE,
-            Keyboard.KEY_NONE,
-            Names.Keys.CATEGORY);
 
     private final InGameInfoCore core = InGameInfoCore.INSTANCE;
 
@@ -54,18 +45,18 @@ public class ClientProxy extends CommonProxy {
 
         ClientConfigurationHandler.propFileInterval.setConfigEntryClass(GuiConfigEntries.NumberSliderEntry.class);
         ClientConfigurationHandler.propscale.setConfigEntryClass(GuiConfigEntries.NumberSliderEntry.class);
-        ClientRegistry.registerKeyBinding(KEY_BINDING_TOGGLE);
     }
 
     @Override
     public void init(FMLInitializationEvent event) {
         super.init(event);
 
-        MinecraftForge.EVENT_BUS.register(Ticker.INSTANCE);
-        FMLCommonHandler.instance().bus().register(Ticker.INSTANCE);
+        final Ticker ticker = new Ticker();
+        MinecraftForge.EVENT_BUS.register(ticker);
+        FMLCommonHandler.instance().bus().register(ticker);
         FMLCommonHandler.instance().bus().register(ClientConfigurationHandler.INSTANCE);
-        FMLCommonHandler.instance().bus().register(KeyInputHandler.INSTANCE);
-        ClientCommandHandler.instance.registerCommand(InGameInfoCommand.INSTANCE);
+        FMLCommonHandler.instance().bus().register(new KeyInputHandler());
+        ClientCommandHandler.instance.registerCommand(new InGameInfoCommand());
         ((IReloadableResourceManager) Minecraft.getMinecraft().getResourceManager())
                 .registerReloadListener(ClientConfigurationHandler.INSTANCE);
     }
@@ -73,7 +64,6 @@ public class ClientProxy extends CommonProxy {
     @Override
     public void postInit(FMLPostInitializationEvent event) {
         PluginLoader.getInstance().postInit(event);
-
         TagRegistry.INSTANCE.init();
     }
 

--- a/src/main/java/com/github/lunatrius/ingameinfo/proxy/ClientProxy.java
+++ b/src/main/java/com/github/lunatrius/ingameinfo/proxy/ClientProxy.java
@@ -3,13 +3,12 @@ package com.github.lunatrius.ingameinfo.proxy;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.IReloadableResourceManager;
 import net.minecraftforge.client.ClientCommandHandler;
-import net.minecraftforge.common.MinecraftForge;
 
 import com.github.lunatrius.ingameinfo.InGameInfoCore;
 import com.github.lunatrius.ingameinfo.command.InGameInfoCommand;
 import com.github.lunatrius.ingameinfo.handler.ClientConfigurationHandler;
 import com.github.lunatrius.ingameinfo.handler.KeyInputHandler;
-import com.github.lunatrius.ingameinfo.handler.Ticker;
+import com.github.lunatrius.ingameinfo.handler.TickerManager;
 import com.github.lunatrius.ingameinfo.integration.PluginLoader;
 import com.github.lunatrius.ingameinfo.reference.Names;
 import com.github.lunatrius.ingameinfo.tag.Tag;
@@ -50,10 +49,7 @@ public class ClientProxy extends CommonProxy {
     @Override
     public void init(FMLInitializationEvent event) {
         super.init(event);
-
-        final Ticker ticker = new Ticker();
-        MinecraftForge.EVENT_BUS.register(ticker);
-        FMLCommonHandler.instance().bus().register(ticker);
+        FMLCommonHandler.instance().bus().register(new TickerManager());
         FMLCommonHandler.instance().bus().register(ClientConfigurationHandler.INSTANCE);
         FMLCommonHandler.instance().bus().register(new KeyInputHandler());
         ClientCommandHandler.instance.registerCommand(new InGameInfoCommand());

--- a/src/main/java/com/github/lunatrius/ingameinfo/tag/Tag.java
+++ b/src/main/java/com/github/lunatrius/ingameinfo/tag/Tag.java
@@ -132,6 +132,11 @@ public abstract class Tag {
         TagPlayerPotion.releaseResources();
     }
 
+    public static void onClientDisconnect() {
+        world = null;
+        player = null;
+    }
+
     public static String getIconTag(Info info) {
         return String.format("{ICON|%s}", info.getIconSpacing());
     }

--- a/src/main/java/com/github/lunatrius/ingameinfo/tag/Tag.java
+++ b/src/main/java/com/github/lunatrius/ingameinfo/tag/Tag.java
@@ -82,11 +82,14 @@ public abstract class Tag {
 
     public static void setServer(MinecraftServer server) {
         Tag.server = server;
-
-        try {
-            setSeed(Tag.server.worldServerForDimension(0).getSeed());
-        } catch (Exception e) {
+        if (Tag.server == null) {
             unsetSeed();
+        } else {
+            try {
+                setSeed(Tag.server.worldServerForDimension(0).getSeed());
+            } catch (Exception e) {
+                unsetSeed();
+            }
         }
     }
 


### PR DESCRIPTION
only register the tick events when connecting to a game and clean up the stuff when disconnecting

![image](https://github.com/user-attachments/assets/a6529c96-475b-4bb0-ae2c-9c1dc0a944b4)
