### PR TITLE
Fix log spam by properly handling missing textures in InfoIcon

### DIFF
--- a/src/main/java/com/github/lunatrius/ingameinfo/client/gui/InfoIcon.java
+++ b/src/main/java/com/github/lunatrius/ingameinfo/client/gui/InfoIcon.java
@@ -2,7 +2,6 @@ package com.github.lunatrius.ingameinfo.client.gui;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.texture.ITextureObject;
 import net.minecraft.util.ResourceLocation;
 
 import org.jetbrains.annotations.NotNull;
@@ -14,6 +13,7 @@ import com.github.lunatrius.ingameinfo.reference.Reference;
 public class InfoIcon extends Info {
 
     private ResourceLocation resourceLocation;
+    private boolean invalidResource;
     private final Vector2f xy0 = new Vector2f();
     private final Vector2f xy1 = new Vector2f();
     private final Vector2f uv0 = new Vector2f();
@@ -49,30 +49,27 @@ public class InfoIcon extends Info {
 
     @Override
     public void drawInfo() {
-        try {
-            ITextureObject texture = Minecraft.getMinecraft().getTextureManager().getTexture(resourceLocation);
-            if (texture == null) {
-                Reference.logger.debug("Unable to find texture for icon {}", resourceLocation);
-                return;
-            }
-
-            GL11.glBindTexture(GL11.GL_TEXTURE_2D, texture.getGlTextureId());
-
-            GL11.glTranslatef(getX(), getY(), 0);
-
-            Tessellator tess = Tessellator.instance;
-            tess.startDrawingQuads();
-            double zLevel = 300;
-            tess.addVertexWithUV(xy0.x, xy1.y, zLevel, uv0.x, uv1.y);
-            tess.addVertexWithUV(xy1.x, xy1.y, zLevel, uv1.x, uv1.y);
-            tess.addVertexWithUV(xy1.x, xy0.y, zLevel, uv1.x, uv0.y);
-            tess.addVertexWithUV(xy0.x, xy0.y, zLevel, uv0.x, uv0.y);
-            tess.draw();
-
-            GL11.glTranslatef(-getX(), -getY(), 0);
-        } catch (Exception e) {
-            Reference.logger.debug(e);
+        if (invalidResource) {
+            return;
         }
+        try {
+            Minecraft.getMinecraft().getTextureManager().bindTexture(resourceLocation);
+        } catch (Exception e) {
+            Reference.logger.error("\"" + resourceLocation + "\" isn't a valid resource location!", e);
+            invalidResource = true;
+        }
+        GL11.glTranslatef(getX(), getY(), 0);
+
+        Tessellator tess = Tessellator.instance;
+        tess.startDrawingQuads();
+        double zLevel = 300;
+        tess.addVertexWithUV(xy0.x, xy1.y, zLevel, uv0.x, uv1.y);
+        tess.addVertexWithUV(xy1.x, xy1.y, zLevel, uv1.x, uv1.y);
+        tess.addVertexWithUV(xy1.x, xy0.y, zLevel, uv1.x, uv0.y);
+        tess.addVertexWithUV(xy0.x, xy0.y, zLevel, uv0.x, uv0.y);
+        tess.draw();
+
+        GL11.glTranslatef(-getX(), -getY(), 0);
     }
 
     @Override


### PR DESCRIPTION
fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20505

This PR fixes the log spam that has been introduced by this commit : https://github.com/GTNewHorizons/InGame-Info-XML/pull/31/commits/c61e14311f99eec6382af49edc7931ea7b849dc4

The proper way to bind textures for rendering is to call `bindTexture(resourceLocation);`, this method will load the texture if it's not already loaded and bind it for rendering.

The previous code was only using `getTexture(resourceLocation)` which would only return the textures if it has been already loaded before by something else, and it would spam an error in the log if that not was the case.