### PR TITLE
[Memory-opti:static allocations:58 MB] stop registering tags for all available potion IDs

### DIFF
--- a/src/main/java/com/github/lunatrius/ingameinfo/tag/TagPlayerPotion.java
+++ b/src/main/java/com/github/lunatrius/ingameinfo/tag/TagPlayerPotion.java
@@ -205,6 +205,8 @@ public abstract class TagPlayerPotion extends Tag {
 
     public static void register() {
         for (int i = 0; i < MAXIMUM_INDEX; i++) {
+            final Potion potion = Potion.potionTypes[i];
+            if (potion == null) continue;
             TagRegistry.INSTANCE.register(new Effect(i).setName("potioneffect"));
             TagRegistry.INSTANCE.register(new Duration(i).setName("potionduration"));
             TagRegistry.INSTANCE.register(new DurationTicks(i).setName("potiondurationticks"));


### PR DESCRIPTION
As it turns out this mod registers tags for all available potions IDs, in vanilla there is 32 potions IDs so it's fine but in GTNH now that we have endless IDs, there is 65,536 available potions IDs which makes the tag registry huge.

I changed it to only register non-null entries of the potion array.

Before:
<img width="726" height="85" alt="image" src="https://github.com/user-attachments/assets/cf060cc1-630e-469e-8538-c6df3827c50a" />

After:
<img width="595" height="94" alt="image" src="https://github.com/user-attachments/assets/a7acc5ac-4030-4010-9e30-88df76f15879" />